### PR TITLE
deprecate flood mapping notebook, point to HydroSAR repo

### DIFF
--- a/SAR_Training/English/Hazards/FloodMappingFromSARImages.ipynb
+++ b/SAR_Training/English/Hazards/FloodMappingFromSARImages.ipynb
@@ -6,6 +6,17 @@
    "source": [
     "![OpenSARlab notebook banner](NotebookAddons/blackboard-banner.png)\n",
     "\n",
+    "<div class=\"alert alert-danger\">\n",
+    "<font face=\"Calibri\" size=\"10\"><b><font color='rgba(200,0,0,0.2)'> <u>This Notebook is Deprecated</u></font></b></font>\n",
+    "\n",
+    "<font face=\"Calibri\" size=\"4\">Current HydroSAR flood mapping workflows can be found in the [HydroSAR GitHub repository](https://github.com/HydroSAR/HydroSAR).\n",
+    "\n",
+    "ASF will no longer support this notebook.\n",
+    "\n",
+    "</font>\n",
+    "</div>\n",
+    "\n",
+    "\n",
     "# Flood Mapping from Single Sentinel-1 SAR Images\n",
     "\n",
     "<img style=\"padding: 7px\" src=\"../Master/NotebookAddons/UAFLogo_A_647.png\" width=\"170\" align=\"right\"/>\n",
@@ -1153,9 +1164,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:.local-hydrosar]",
+   "display_name": "base",
    "language": "python",
-   "name": "conda-env-.local-hydrosar-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1167,7 +1178,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.11.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
HydroSAR workflows have been updated since this notebook was added. We recommend using notebooks in the [HydroSAR repo](https://github.com/HydroSAR/HydroSAR) instead of outdated duplicates in this repo.